### PR TITLE
Fix file not truncated when writing

### DIFF
--- a/BinaryXML/Extensions.cs
+++ b/BinaryXML/Extensions.cs
@@ -58,7 +58,7 @@ namespace BinaryXML
                 try
                 {
                     if (failed) Console.WriteLine();
-                    return info.OpenWrite();
+                    return info.Open(FileMode.Create, FileAccess.Write);
                 }
                 catch (IOException)
                 {


### PR DESCRIPTION
According to the [doc](https://docs.microsoft.com/en-us/dotnet/api/system.io.fileinfo.openwrite?view=netframework-4.7.2#remarks):

> The OpenWrite method opens a file if one already exists for the file path, or creates a new file if one does not exist. For an existing file, it does not append the new text to the existing text. Instead, **it overwrites the existing characters with the new characters**.

So if we first convert a map to xml, then replace the file with an empty map without file name changed, the output xml can be a mix of two xmls and unable to convert back to binary. This PR changes the file mode to `FileMode.Create` so it will truncate the existing file first.