### PR TITLE
Fix incorrect tiles conversion in xml -> binary

### DIFF
--- a/BinaryXML/XML/Element.cs
+++ b/BinaryXML/XML/Element.cs
@@ -25,7 +25,7 @@ namespace BinaryXML
                 {
                     Attributes.Add(new Attribute(Attribute._INNERTEXT,
                         (AttributeType)int.Parse(text.Value[0].ToString()),
-                        text.Value.Substring(1)
+                        text.Value.Substring(2)
                     ));
                 }
             }


### PR DESCRIPTION
Inner texts have a new line character between type and actual content, so we should substring form 2 instead of 1